### PR TITLE
Fix lua error in 9.2.5

### DIFF
--- a/BlizzardRaidFramesFix.lua
+++ b/BlizzardRaidFramesFix.lua
@@ -1143,7 +1143,8 @@ hooksecurefunc(
 )
 
 for _, menu in ipairs({"SELF", "VEHICLE", "PET", "RAID_PLAYER", "PARTY", "PLAYER", "TARGET"}) do
-    local buttons = UnitPopupManager:GetMenu(menu):GetMenuButtons();
+    local originalMenu = UnitPopupManager:GetMenu(menu);
+    local buttons = originalMenu:GetMenuButtons();
     local buttons2 = {};
 
     for i = 1, #buttons do
@@ -1155,6 +1156,7 @@ for _, menu in ipairs({"SELF", "VEHICLE", "PET", "RAID_PLAYER", "PARTY", "PLAYER
     end
 
     local unitPopupMenu = CreateFromMixins(UnitPopupTopLevelMenuMixin);
+    unitPopupMenu.IsMenu = originalMenu.IsMenu;
     function unitPopupMenu:GetMenuButtons()
         return buttons2;
     end

--- a/BlizzardRaidFramesFix.lua
+++ b/BlizzardRaidFramesFix.lua
@@ -1157,7 +1157,7 @@ for _, menu in ipairs({"SELF", "VEHICLE", "PET", "RAID_PLAYER", "PARTY", "PLAYER
 
     local unitPopupMenu = CreateFromMixins(UnitPopupTopLevelMenuMixin);
     unitPopupMenu.IsMenu = originalMenu.IsMenu;
-    function unitPopupMenu:GetMenuButtons()
+    unitPopupMenu.GetMenuButtons = function ()
         return buttons2;
     end
 

--- a/BlizzardRaidFramesFix.lua
+++ b/BlizzardRaidFramesFix.lua
@@ -1143,18 +1143,23 @@ hooksecurefunc(
 )
 
 for _, menu in ipairs({"SELF", "VEHICLE", "PET", "RAID_PLAYER", "PARTY", "PLAYER", "TARGET"}) do
-    local buttons = UnitPopupMenus[menu]
-    local buttons2 = {}
+    local buttons = UnitPopupManager:GetMenu(menu):GetMenuButtons();
+    local buttons2 = {};
 
     for i = 1, #buttons do
         local button = buttons[i]
-
-        if button ~= "SET_FOCUS" and button ~= "CLEAR_FOCUS" and button ~= "PVP_REPORT_AFK" then
+        local buttonText = button.GetText and button:GetText();
+        if buttonText ~= SET_FOCUS and buttonText ~= CLEAR_FOCUS and buttonText ~= PVP_REPORT_AFK then
             tinsert(buttons2, button)
         end
     end
 
-    UnitPopupMenus["_BRFF_" .. menu] = buttons2
+    local unitPopupMenu = CreateFromMixins(UnitPopupTopLevelMenuMixin);
+    function unitPopupMenu:GetMenuButtons()
+        return buttons2;
+    end
+
+    UnitPopupManager:RegisterMenu("_BRFF_" .. menu, unitPopupMenu);
 end
 
 function CompactUnitFrameDropDown_Initialize(self)


### PR DESCRIPTION
With 9.2.5, UnitPopupMenus[menu] is no longer a list of buttons.
It contains an object of Button class derived from UnitPopupTopLevelMenuMixin, and buttons are returned by override function GetMenuButtons.

This fix creates a copy of the original menu but removes SET_FOCUS, CLEAR_FOCUS, PVP_REPORT_AFK buttons in the GetMenuButtons override.

Verified no more lua errors pop up when right clicking the raid frames